### PR TITLE
Updated code to support custom cells like proposed on #21

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -80,6 +80,8 @@ public final class DropDown: UIView {
 	private let dismissableView = UIView()
 	private let tableViewContainer = UIView()
 	private let tableView = UITableView()
+	private var templateCell: DropDownCell!
+
 
 	/// The view to which the drop down will displayed onto.
 	public weak var anchorView: AnchorView? {
@@ -273,6 +275,7 @@ public final class DropDown: UIView {
     public var cellNib = UINib(nibName: "DropDownCell", bundle: NSBundle(forClass: DropDownCell.self)) {
         didSet {
             tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
+			templateCell = nil
             reloadAllComponents()
         }
     }
@@ -411,7 +414,7 @@ private extension DropDown {
 
 	func setup() {
 		tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
-		
+
 		dispatch_async(dispatch_get_main_queue()) {
 			//HACK: If not done in dispatch_async on main queue `setupUI` will have no effect
 			self.updateConstraintsIfNeeded()
@@ -657,7 +660,10 @@ extension DropDown {
 	}
 	
 	private func fittingWidth() -> CGFloat {
-		let templateCell = cellNib.instantiateWithOwner(nil, options: nil)[0] as! DropDownCell
+		if templateCell == nil {
+			templateCell = cellNib.instantiateWithOwner(nil, options: nil)[0] as! DropDownCell
+		}
+		
 		var maxWidth: CGFloat = 0
 		
 		for item in dataSource {

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -902,7 +902,7 @@ extension DropDown: UITableViewDataSource, UITableViewDelegate {
 			cell.optionLabel.text = dataSource[index]
 		}
         
-        customCellConfiguration?(index, dataSource[index], cell)
+		customCellConfiguration?(index, dataSource[index], cell)
 
 		return cell
 	}

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -410,7 +410,7 @@ public final class DropDown: UIView {
 private extension DropDown {
 
 	func setup() {
-        tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
+		tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
 		
 		dispatch_async(dispatch_get_main_queue()) {
 			//HACK: If not done in dispatch_async on main queue `setupUI` will have no effect
@@ -901,6 +901,7 @@ extension DropDown: UITableViewDataSource, UITableViewDelegate {
 		} else {
 			cell.optionLabel.text = dataSource[index]
 		}
+        
         customCellConfiguration?(index, dataSource[index], cell)
 
 		return cell

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -272,14 +272,14 @@ public final class DropDown: UIView {
      
      Changing the cell nib automatically reloads the drop down.
      */
-    public var cellNib = UINib(nibName: "DropDownCell", bundle: NSBundle(forClass: DropDownCell.self)) {
-        didSet {
-            tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
+	public var cellNib = UINib(nibName: "DropDownCell", bundle: NSBundle(forClass: DropDownCell.self)) {
+		didSet {
+			tableView.registerNib(cellNib, forCellReuseIdentifier: DPDConstant.ReusableIdentifier.DropDownCell)
 			templateCell = nil
-            reloadAllComponents()
-        }
-    }
-    
+			reloadAllComponents()
+		}
+	}
+	
 	//MARK: Content
 
 	/**

--- a/DropDown/src/DropDownCell.swift
+++ b/DropDown/src/DropDownCell.swift
@@ -8,13 +8,10 @@
 
 import UIKit
 
-internal final class DropDownCell: UITableViewCell {
-	
-	//MARK: - Properties
-	static let Nib = UINib(nibName: "DropDownCell", bundle: NSBundle(forClass: DropDownCell.self))
-	
+public class DropDownCell: UITableViewCell {
+		
 	//UI
-	@IBOutlet weak var optionLabel: UILabel!
+	@IBOutlet public weak var optionLabel: UILabel!
 	
 	var selectedBackgroundColor: UIColor?
 
@@ -22,31 +19,31 @@ internal final class DropDownCell: UITableViewCell {
 
 //MARK: - UI
 
-internal extension DropDownCell {
+extension DropDownCell {
 	
-	override func awakeFromNib() {
+	override public func awakeFromNib() {
 		super.awakeFromNib()
 		
 		backgroundColor = UIColor.clearColor()
 	}
 	
-	override var selected: Bool {
+	override public var selected: Bool {
 		willSet {
 			setSelected(newValue, animated: false)
 		}
 	}
 	
-	override var highlighted: Bool {
+	override public var highlighted: Bool {
 		willSet {
 			setSelected(newValue, animated: false)
 		}
 	}
 	
-	override func setHighlighted(highlighted: Bool, animated: Bool) {
+	override public func setHighlighted(highlighted: Bool, animated: Bool) {
 		setSelected(highlighted, animated: animated)
 	}
 	
-	override func setSelected(selected: Bool, animated: Bool) {
+	override public func setSelected(selected: Bool, animated: Bool) {
 		let executeSelection: () -> Void = { [unowned self] in
 			if let selectedBackgroundColor = self.selectedBackgroundColor {
 				if selected {


### PR DESCRIPTION
This PR includes changes as proposed on #21 

I had to also remove the static template for fitting calculations, as it can now depend on custom cells. Not sure if we should also call the custom cell block in that case to get the best fitting width possible.

Note that the API is still the same and fully backwards compatible.