### PR TITLE
Added patch for issue #72

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -736,7 +736,7 @@ extension DropDown {
 	*/
 	@discardableResult
 	public func show() -> (canBeDisplayed: Bool, offscreenHeight: CGFloat?) {
-		if self == DropDown.VisibleDropDown {
+		if self == DropDown.VisibleDropDown && DropDown.VisibleDropDown?.isHidden == false { // added condition - DropDown.VisibleDropDown?.isHidden == false -> to resolve forever hiding dropdown issue when continuous taping on button - Kartik Patel - 2016-12-29
 			return (true, 0)
 		}
 


### PR DESCRIPTION
Added condition to resolve forever hiding dropdown issue when
continuous taping on button - issue #72 - Kartik Patel - 2016-12-29.
This condition additional check that is drop down visible then only it
return from function without further execution otherwise execute
further code.