### PR TITLE
Layout view before showing to fix row selection

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -767,6 +767,8 @@ extension DropDown {
 		isHidden = false
 		tableViewContainer.transform = downScaleTransform
 
+		layoutIfNeeded()
+
 		UIView.animate(
 			withDuration: animationduration,
 			delay: 0,


### PR DESCRIPTION
This change fixes selection when you show drop down first time. Fixes bug report #49. I don't think fix in #60 is correct.

Constraints of table view were updated but at this point frame was not updated yet. Forcing it by calling `layoutIfNeeded()` solves the problem.