### PR TITLE
Add offset from the bottom of the window if dropdown is shown below the anchor

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -118,6 +118,14 @@ public final class DropDown: UIView {
 		didSet { setNeedsUpdateConstraints() }
 	}
 
+    /**
+    The offset from the bottom of the window when the drop down is shown below the anchor view.
+    DropDown applies this offset only if keyboard is hidden.
+    */
+    public var offsetFromWindowBottom = CGFloat(0) {
+        didSet { setNeedsUpdateConstraints() }
+    }
+    
 	/**
 	The width of the drop down.
 
@@ -625,7 +633,7 @@ extension DropDown {
 		let y = anchorViewY + bottomOffset.y
 		
 		let maxY = y + tableHeight
-		let windowMaxY = window.bounds.maxY - DPDConstant.UI.HeightPadding
+		let windowMaxY = window.bounds.maxY - DPDConstant.UI.HeightPadding - offsetFromWindowBottom
 		
 		let keyboardListener = KeyboardListener.sharedInstance
 		let keyboardMinY = keyboardListener.keyboardFrame.minY - DPDConstant.UI.HeightPadding


### PR DESCRIPTION
Add configurable offset from the bottom of the window if dropdown is shown below the anchor view. This will allow to configure DropDown not to overlap important UI elements in the bottom of the screen.