### PR TITLE
fix/unowned: unowned -> weak on one gcd async closure

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -481,8 +481,8 @@ extension DropDown {
 
 		tableView.isScrollEnabled = layout.offscreenHeight > 0
 
-		DispatchQueue.main.async { [unowned self] in
-			self.tableView.flashScrollIndicators()
+		DispatchQueue.main.async { [weak self] in
+			self?.tableView.flashScrollIndicators()
 		}
 
 		super.updateConstraints()


### PR DESCRIPTION
This is similar to #68, but branches off of current master branch (swift3). 

Fixes an issue that seems to be frequent among other users where lib crashes on `DropDown:485` as self can be nilled out there. One reason might be that our `DropDown` instance is not allocated properly (ie only local scope as suggested in #47 (here)[https://github.com/AssistoLab/DropDown/issues/47#issuecomment-251683268]. For me, this happened in tests done with Nimble async matchers and was a blocker for using the pod (ie. app worked perfectly fine but tests crashed).

I'm assuming this fixes #45, #47, #48, even if the exact context there might have been different.