### PR TITLE
Allow setting the scrollPosition when selecting a row

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -916,10 +916,10 @@ extension DropDown {
 	}
 
 	/// (Pre)selects a row at a certain index.
-	public func selectRow(at index: Index?) {
+	public func selectRow(at index: Index?, scrollPosition: UITableViewScrollPosition = .none) {
 		if let index = index {
             tableView.selectRow(
-                at: IndexPath(row: index, section: 0), animated: true, scrollPosition: .none
+                at: IndexPath(row: index, section: 0), animated: true, scrollPosition: scrollPosition
             )
             selectedRowIndices.insert(index)
 		} else {

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -977,8 +977,8 @@ extension DropDown {
 	}
 
     //MARK: Objective-C methods for converting the Swift type Index
-    @objc public func selectRow(_ index: Int) {
-        self.selectRow(at:Index(index))
+    @objc public func selectRow(_ index: Int, scrollPosition: UITableViewScrollPosition = .none) {
+        self.selectRow(at:Index(index), scrollPosition: scrollPosition)
     }
     
     @objc public func clearSelection() {


### PR DESCRIPTION
Defaults to `.none`

### What where you trying to do

When the list is long and you want to pre-select an option, the dropdown table always starts at the top. Would be nice if it can scroll to the pre-selected row automatically.

### How to reproduce the issue

Just have a long list, and call `selectRow`