### PR TITLE
call tableView.reloadData() from main thread only

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -911,8 +911,10 @@ extension DropDown {
 	and `cellConfiguration` implicitly calls `reloadAllComponents()`.
 	*/
 	public func reloadAllComponents() {
-		tableView.reloadData()
-		setNeedsUpdateConstraints()
+		DispatchQueue.main.async {
+			self.tableView.reloadData()
+			self.setNeedsUpdateConstraints()
+		}
 	}
 
 	/// (Pre)selects a row at a certain index.


### PR DESCRIPTION
e.g. updating dataSource from background thread throws an ui exception. this should be handled at the source.