### PR TITLE
Added getter for Drop Down's frame in relation to the users view

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -151,6 +151,13 @@ public final class DropDown: UIView {
 	public var width: CGFloat? {
 		didSet { setNeedsUpdateConstraints() }
 	}
+    
+    /**
+     The frame of the drop down in relation to your view.
+     */
+    public var relativeFrame: CGRect {
+        get { return tableViewContainer.frame }
+    }
 
 	/**
 	arrowIndication.x


### PR DESCRIPTION
Needed a fix for my own project where my anchor view is dynamic and the width might have made the drop down's view go off screen. This gives us the relative frame of the drop down that we can test against while setting our offsets.