### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ Carthage/Build
 # Mac OS X
 .DS_Store
 
+# SwiftPackageManager #
+Packages
+.build/
+xcuserdata
+DerivedData/
+#*.xcodeproj Keeping this here so we maintain Carthage support

--- a/DropDown/helpers/DPDConstants.swift
+++ b/DropDown/helpers/DPDConstants.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 internal struct DPDConstant {
@@ -55,3 +57,5 @@ internal struct DPDConstant {
 	}
 
 }
+
+#endif

--- a/DropDown/helpers/DPDKeyboardListener.swift
+++ b/DropDown/helpers/DPDKeyboardListener.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 internal final class KeyboardListener {
@@ -66,3 +68,5 @@ extension KeyboardListener {
 	}
 	
 }
+
+#endif

--- a/DropDown/helpers/DPDUIView+Extension.swift
+++ b/DropDown/helpers/DPDUIView+Extension.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 //MARK: - Constraints
@@ -55,3 +57,5 @@ internal extension UIWindow {
 	}
 	
 }
+
+#endif

--- a/DropDown/src/DropDown+Appearance.swift
+++ b/DropDown/src/DropDown+Appearance.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 extension DropDown {
@@ -29,3 +31,5 @@ extension DropDown {
 	}
 
 }
+
+#endif

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 public typealias Index = Int
@@ -1194,3 +1196,5 @@ private extension DispatchQueue {
 		}
 	}
 }
+
+#endif

--- a/DropDown/src/DropDownCell.swift
+++ b/DropDown/src/DropDownCell.swift
@@ -6,6 +6,8 @@
 //  Copyright (c) 2015 Kevin Hirsch. All rights reserved.
 //
 
+#if os(iOS)
+
 import UIKit
 
 open class DropDownCell: UITableViewCell {
@@ -72,3 +74,5 @@ extension DropDownCell {
 	}
 	
 }
+
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "DropDown",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "DropDown",
+            targets: ["DropDown"])
+    ],
+    targets: [
+        .target(
+            name: "DropDown",
+            path: "DropDown"
+        )
+    ]
+)


### PR DESCRIPTION
Addresses https://github.com/AssistoLab/DropDown/issues/247

Because SPM is multi-platform and UIKit is iOS-specific, I had to add `#if os(iOS)` blocks in each file that imported UIKit.