### PR TITLE
Adding the option to not-animate/animate the selection

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -749,13 +749,36 @@ extension DropDown {
 		let x = anchorViewX + topOffset.x
 		var y = (anchorViewMaxY + topOffset.y) - tableHeight
 
-		let windowY = window.bounds.minY + DPDConstant.UI.HeightPadding
-
-		if y < windowY {
-			offscreenHeight = abs(y - windowY)
-			y = windowY
+		var windowY = window.bounds.minY
+		if #available(iOS 11.0, *) {
+		    windowY += window.safeAreaInsets.top
+		} else {
+		    windowY +=  DPDConstant.UI.HeightPadding
 		}
-		
+
+			if y < windowY {
+				offscreenHeight = abs(y - windowY)
+				y = windowY
+		} else {
+		    let maxY = y + tableHeight
+
+		    var windowMaxY = window.bounds.maxY - offsetFromWindowBottom
+		    if #available(iOS 11.0, *) {
+			windowMaxY -= window.safeAreaInsets.bottom
+		    } else {
+			windowMaxY -=  DPDConstant.UI.HeightPadding
+		    }
+
+		    let keyboardListener = KeyboardListener.sharedInstance
+		    let keyboardMinY = keyboardListener.keyboardFrame.minY - DPDConstant.UI.HeightPadding
+
+		    if keyboardListener.isVisible && maxY > keyboardMinY {
+			offscreenHeight = abs(maxY - keyboardMinY)
+		    } else if maxY > windowMaxY {
+			offscreenHeight = abs(maxY - windowMaxY)
+		    }
+		}
+        
 		let width = self.width ?? (anchorView?.plainView.bounds.width ?? fittingWidth()) - topOffset.x
 		
 		return (x, y, width, offscreenHeight)

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -973,10 +973,10 @@ extension DropDown {
 	}
 
 	/// (Pre)selects a row at a certain index.
-	public func selectRow(at index: Index?, scrollPosition: UITableView.ScrollPosition = .none) {
+	public func selectRow(at index: Index?, scrollPosition: UITableView.ScrollPosition = .none, animated: Bool = true) {
 		if let index = index {
             tableView.selectRow(
-                at: IndexPath(row: index, section: 0), animated: true, scrollPosition: scrollPosition
+                at: IndexPath(row: index, section: 0), animated: animated, scrollPosition: scrollPosition
             )
             selectedRowIndices.insert(index)
 		} else {


### PR DESCRIPTION
When opening the menu, you want to have the dropdown options already displayed (and not displayed and than scroll to as currently), therefor the option animated = false is better...

this is a non-breaking change