### PR TITLE
Modified for custom DropDown Height

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -153,7 +153,16 @@ public final class DropDown: UIView {
 	public var width: CGFloat? {
 		didSet { setNeedsUpdateConstraints() }
 	}
-
+    
+    /* changes for custom height */
+    /**
+    The height of the drop down.
+    */
+    public var height: CGFloat? {
+        didSet { setNeedsUpdateConstraints() }
+    }
+    /* end changes */
+    
 	/**
 	arrowIndication.x
 
@@ -578,8 +587,20 @@ extension DropDown {
 		xConstraint.constant = layout.x
 		yConstraint.constant = layout.y
 		widthConstraint.constant = layout.width
-		heightConstraint.constant = layout.visibleHeight
-
+        
+        /* changes for custom height */
+        // heightConstraint.constant = layout.visibleHeight
+        if let height = self.height {
+            if layout.visibleHeight >= height {
+                heightConstraint.constant = self.height ?? layout.visibleHeight
+            } else {
+                heightConstraint.constant = layout.visibleHeight
+            }
+        } else {
+            heightConstraint.constant = layout.visibleHeight
+        }
+        /* end changes */
+        
 		tableView.isScrollEnabled = layout.offscreenHeight > 0
 
 		DispatchQueue.main.async { [weak self] in
@@ -750,12 +771,24 @@ extension DropDown {
 		var y = (anchorViewMaxY + topOffset.y) - tableHeight
 
 		let windowY = window.bounds.minY + DPDConstant.UI.HeightPadding
-
-		if y < windowY {
-			offscreenHeight = abs(y - windowY)
-			y = windowY
-		}
-		
+        
+        /* changes for custom height */
+        /*
+         if y < windowY {
+         offscreenHeight = abs(y - windowY)
+         y = windowY
+         }
+         */
+        if y < windowY {
+            offscreenHeight = abs(y - windowY)
+            if let height = self.height {
+                y = anchorViewMaxY + topOffset.y - height
+            } else {
+                y = windowY
+            }
+        }
+        /* end changes */
+        
 		let width = self.width ?? (anchorView?.plainView.bounds.width ?? fittingWidth()) - topOffset.x
 		
 		return (x, y, width, offscreenHeight)


### PR DESCRIPTION
In pod file DropDown.swift do following changes for custom height

Step 1 : Add this below width property

```
public var height: CGFloat? {
       didSet { setNeedsUpdateConstraints() }
 }
```
Step 2 : In public override func updateConstraints() do this

```
replace 
`heightConstraint.constant = layout.visibleHeight `
with following

if let height = self.height {
    if layout.visibleHeight >= height {
         heightConstraint.constant = self.height ?? layout.visibleHeight
     } else {
         heightConstraint.constant = layout.visibleHeight
     }
} else {
     heightConstraint.constant = layout.visibleHeight
}
```
Step 3 : In fileprivate func computeLayoutForTopDisplay(window: UIWindow) -> ComputeLayoutTuple do this

replace 

```
if y < windowY {
    offscreenHeight = abs(y - windowY)
    y = windowY
}
```

with following
```
if y < windowY {
 offscreenHeight = abs(y - windowY)
  if let height = self.height {
         y = anchorViewMaxY + topOffset.y - height
    } else {
          y = windowY
    }
 }
```
Uses

```
let dropDown = DropDown()
dropDown.height = 50
```
If height is not set, the dropdown height will be its content size and if content size is greater than screen/superview size then it will stop at view bounds and dropdown's scroll is activated.
If you don't want that set height as suggested above.
After setting height:- 
1. if your content size is less than your assigned height it will wrap to its content means dropdown will have height of its content size, you will see all dropdown option in list.
2. If content size exceeds assigned height then dropdown will have its assigned height and scroll will be activated.