### PR TITLE
Add separatorInset for customization

### DIFF
--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -20,7 +20,7 @@ private typealias ComputeLayoutTuple = (x: CGFloat, y: CGFloat, width: CGFloat, 
 
 /// Can be `UIView` or `UIBarButtonItem`.
 @objc
-public protocol AnchorView: class {
+public protocol AnchorView: AnyObject {
 
 	var plainView: UIView { get }
 

--- a/DropDown/src/DropDown.swift
+++ b/DropDown/src/DropDown.swift
@@ -551,6 +551,7 @@ private extension DropDown {
 		tableView.separatorColor = separatorColor
 		tableView.layer.cornerRadius = cornerRadius
 		tableView.layer.masksToBounds = true
+        tableView.separatorInset.left = 0
 	}
 
 }


### PR DESCRIPTION
### 🪫 **[Before change]**

When implementing a custom drop-down menu, a **separator** is often needed.

dropDown.separatorColor's default color is `.clear` right?

But if you use `dropDown.separatorColor = .black` here, it looks like this

<img width="300" alt="drop1" src="https://github.com/AssistoLab/DropDown/assets/88179341/cbe6f373-d280-47e4-9d2c-2f83dc41f4eb">

Usually, there may be people who want to fill the `left side`.

What if you add **my code**?  `tableView.separatorInset.left = 0`

---

### 🪫 **[After change]**

<img width="300" alt="drop2" src="https://github.com/AssistoLab/DropDown/assets/88179341/8ed7092d-c55b-4bfa-a738-1e11a1c767fd">

good

---

⭐️ But do you see the `Separator` in the bottom cell?
It's really a little uncomfortable

<img width="301" alt="image" src="https://github.com/AssistoLab/DropDown/assets/88179341/b3c81dc1-1630-48c1-b9da-469447d31b0a">

<br>

That's okay~

We have `customCellConfiguration`~

Just create a `CGRect` with the same color as dropDown in `customCellConfiguration` and add it to the bottom of dropDown.

Like this 

```
dropDown.customCellConfiguration = { (index: Index, item: String, cell: DropDownCell) -> Void in
            let lastDivideLineRemove = UIView(frame: CGRect(origin: CGPoint(x: 0, y: 119), size: CGSize(width: 170, height: 10)))
            lastDivideLineRemove.backgroundColor = .white // ⭐️ Same as the background color of dropDown
            cell.addSubview(lastDivideLineRemove)
        }

```

### 🍎 **Result**

<img width="300" alt="drop3" src="https://github.com/AssistoLab/DropDown/assets/88179341/61d858d1-51a7-44dd-baff-3c436107d03b">

---

### 🤔 **Review**

```
dropDown.customCellConfiguration = { (index, item, cell) in
      cell.separatorInset = .zero
      cell.layoutMargins = .zero
}
```

You can add it like this, but I think it's better to just add `tableView.separatorInset.left = 0`  😄

